### PR TITLE
Add CV download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,8 @@ Built with ❤️ by Dylan Warrener
 dylan-warrener.github.io
 GitHub • LinkedIn • Email
 
+To enable the **CV** download link in the navigation bar, place your CV PDF at
+`public/CV.pdf` in the project root. The file will be served statically and
+downloaded when visitors click the CV button.
+
 Feel free to explore the code, submit feedback, or reach out if you have any questions or collaboration ideas!

--- a/src/components/AppNavBar.vue
+++ b/src/components/AppNavBar.vue
@@ -7,6 +7,7 @@
     <v-btn to="/skills" variant="text" class="mx-2">Skills</v-btn>
     <v-btn to="/about" variant="text" class="mx-2">About</v-btn>
     <v-btn to="/contact" variant="text" class="mx-2">Contact</v-btn>
+    <v-btn href="/CV.pdf" download variant="text" class="mx-2">CV</v-btn>
   </v-app-bar>
 </template>
 <script setup lang="ts"></script>


### PR DESCRIPTION
## Summary
- expose public folder for static assets
- add CV button in the navigation bar
- document where to place CV file

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68667676d3ec83329f17bdc863882bd1